### PR TITLE
Detect browser language and persist user preference

### DIFF
--- a/src/components/common/LanguageSelector.astro
+++ b/src/components/common/LanguageSelector.astro
@@ -75,6 +75,7 @@ function getLocalizedPath(lang: string, currentPath: string) {
             } group flex items-center px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors`}
             role="menuitem"
             tabindex="-1"
+            data-lang-option={lang}
           >
             <span class="mr-3">
               {lang === "es" && "🇪🇸"}
@@ -133,6 +134,18 @@ function getLocalizedPath(lang: string, currentPath: string) {
       if (event.key === "Escape") {
         dropdown.classList.add("hidden");
       }
+    });
+
+    dropdown.querySelectorAll("[data-lang-option]").forEach((link) => {
+      (link as HTMLElement).addEventListener("click", () => {
+        const lang = (link as HTMLElement).getAttribute("data-lang-option");
+        if (!lang) return;
+        try {
+          window.localStorage.setItem("preferredLanguage", lang);
+        } catch (_error) {
+          // ignore storage errors
+        }
+      });
     });
   }
 

--- a/src/components/common/MobileSettings.astro
+++ b/src/components/common/MobileSettings.astro
@@ -98,6 +98,7 @@ function getFlagEmoji(lang: string) {
                   ? "bg-indigo-50 dark:bg-indigo-900/20 text-indigo-700 dark:text-indigo-300"
                   : "text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700"
               } group flex items-center px-3 py-2 text-sm rounded-md transition-colors cursor-pointer`}
+              data-lang-option={lang}
             >
               <span class="text-lg mr-3">{getFlagEmoji(lang)}</span>
               <span class="flex-1">{name}</span>
@@ -167,6 +168,18 @@ function getFlagEmoji(lang: string) {
             applyTheme(currentTheme === "dark" ? "light" : "dark");
           }
         );
+      });
+
+      panel.querySelectorAll("[data-lang-option]").forEach((link) => {
+        (link as HTMLElement).addEventListener("click", () => {
+          const lang = (link as HTMLElement).getAttribute("data-lang-option");
+          if (!lang) return;
+          try {
+            window.localStorage.setItem("preferredLanguage", lang);
+          } catch (_error) {
+            // ignore storage errors
+          }
+        });
       });
     });
   }

--- a/src/components/common/PreferredLanguageRedirect.astro
+++ b/src/components/common/PreferredLanguageRedirect.astro
@@ -1,0 +1,74 @@
+---
+import { languages, defaultLang } from "@utils/i18n";
+
+const supportedLanguages = Object.keys(languages);
+---
+
+<script is:inline define:vars={{ supportedLanguages, defaultLanguage: defaultLang }}>
+  (() => {
+    if (typeof window === "undefined") return;
+
+    const supported = supportedLanguages;
+    const defaultLang = defaultLanguage;
+
+    const persistPreference = (lang) => {
+      try {
+        window.localStorage.setItem("preferredLanguage", lang);
+      } catch (_error) {
+        /* ignore storage errors */
+      }
+    };
+
+    const pathSegments = window.location.pathname.split("/").filter(Boolean);
+    const currentLang =
+      pathSegments.length > 0 && supported.includes(pathSegments[0])
+        ? pathSegments[0]
+        : null;
+
+    if (currentLang) {
+      persistPreference(currentLang);
+      return;
+    }
+
+    let preferred = null;
+
+    try {
+      const stored = window.localStorage.getItem("preferredLanguage");
+      if (stored && supported.includes(stored)) {
+        preferred = stored;
+      }
+    } catch (_error) {
+      preferred = null;
+    }
+
+    if (!preferred) {
+      const browserLanguages =
+        Array.isArray(navigator.languages) && navigator.languages.length
+          ? navigator.languages
+          : [navigator.language];
+
+      for (const lang of browserLanguages) {
+        if (!lang) continue;
+        const normalized = String(lang).toLowerCase().split("-")[0];
+        if (supported.includes(normalized)) {
+          preferred = normalized;
+          break;
+        }
+      }
+    }
+
+    if (!preferred) {
+      preferred = defaultLang;
+    }
+
+    if (preferred === defaultLang) {
+      persistPreference(defaultLang);
+      return;
+    }
+
+    const { pathname, search, hash } = window.location;
+    const redirectPath = pathname === "/" ? `/${preferred}` : `/${preferred}${pathname}`;
+
+    window.location.replace(`${redirectPath}${search || ""}${hash || ""}`);
+  })();
+</script>

--- a/src/components/common/PreferredLanguageRedirect.astro
+++ b/src/components/common/PreferredLanguageRedirect.astro
@@ -2,14 +2,25 @@
 import { languages, defaultLang } from "@utils/i18n";
 
 const supportedLanguages = Object.keys(languages);
+const fallbackLanguage = "en" in languages ? "en" : defaultLang;
 ---
 
-<script is:inline define:vars={{ supportedLanguages, defaultLanguage: defaultLang }}>
+<script
+  is:inline
+  define:vars={{
+    supportedLanguages,
+    defaultLanguage: defaultLang,
+    fallbackLanguage,
+  }}
+>
   (() => {
     if (typeof window === "undefined") return;
 
     const supported = supportedLanguages;
     const defaultLang = defaultLanguage;
+    const fallbackLang = supported.includes(fallbackLanguage)
+      ? fallbackLanguage
+      : defaultLang;
 
     const persistPreference = (lang) => {
       try {
@@ -58,7 +69,7 @@ const supportedLanguages = Object.keys(languages);
     }
 
     if (!preferred) {
-      preferred = defaultLang;
+      preferred = fallbackLang;
     }
 
     if (preferred === defaultLang) {
@@ -69,6 +80,7 @@ const supportedLanguages = Object.keys(languages);
     const { pathname, search, hash } = window.location;
     const redirectPath = pathname === "/" ? `/${preferred}` : `/${preferred}${pathname}`;
 
+    persistPreference(preferred);
     window.location.replace(`${redirectPath}${search || ""}${hash || ""}`);
   })();
 </script>

--- a/src/components/common/SettingsButton.astro
+++ b/src/components/common/SettingsButton.astro
@@ -110,6 +110,7 @@ function getFlagEmoji(lang: string) {
                 } group flex items-center px-3 py-2 text-sm rounded-md transition-colors duration-200 cursor-pointer`}
                 role="menuitem"
                 tabindex="-1"
+                data-lang-option={lang}
               >
                 <span class="text-lg mr-3">{getFlagEmoji(lang)}</span>
                 <span class="flex-1">{name}</span>
@@ -223,6 +224,20 @@ function getFlagEmoji(lang: string) {
         closeDropdown(container as HTMLElement);
       });
     });
+
+    settingsDropdown
+      .querySelectorAll("[data-lang-option]")
+      .forEach((link) => {
+        (link as HTMLElement).addEventListener("click", () => {
+          const lang = (link as HTMLElement).getAttribute("data-lang-option");
+          if (!lang) return;
+          try {
+            window.localStorage.setItem("preferredLanguage", lang);
+          } catch (_error) {
+            // ignore storage errors
+          }
+        });
+      });
   }
 
   function initSettingsButtons() {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,6 +3,7 @@ import BasicScripts from "@components/common/BasicScripts.astro";
 import "../styles/global.css";
 import ApplyColorMode from "@components/common/ApplyColorMode.astro";
 import AnimatedBackground from "@components/ui/AnimatedBackground.astro";
+import PreferredLanguageRedirect from "@components/common/PreferredLanguageRedirect.astro";
 import { ClientRouter } from "astro:transitions";
 import type { MetaData } from "@utils/types";
 
@@ -53,6 +54,7 @@ const description = metadata?.description || defaultDescription;
         : "index,follow"}
     />
 
+    <PreferredLanguageRedirect />
     <ApplyColorMode />
     <ClientRouter />
   </head>


### PR DESCRIPTION
## Summary
- agrega un script global que detecta el idioma del navegador o preferencia almacenada y redirige automáticamente a la versión disponible correspondiente
- integra el nuevo script en el layout principal para ejecutarlo antes de cargar el contenido
- guarda la selección de idioma en todos los selectores para recordar la preferencia del usuario

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9838ca5a0832dbfb2e06c59a477dc